### PR TITLE
Fixed puns.json typos

### DIFF
--- a/puns.json
+++ b/puns.json
@@ -180,7 +180,7 @@
     "punchline": "A: They put in a lot of shifts!"
   },
   {
-    "pun": "Q: Why don't progammers like nature?",
+    "pun": "Q: Why don't programmers like nature?",
     "punchline": "A: Too many bugs!"
   },
   {


### PR DESCRIPTION
Fixed : "pun": "Q: Why don't progammers like nature?"
to: "pun": "Q: Why don't programmers like nature?",
#no_typos_left