### PR TITLE
Improve parroty pun

### DIFF
--- a/puns.json
+++ b/puns.json
@@ -220,7 +220,7 @@
     "punchline": "A: To get to the other slide!"
   },
   {
-    "pun": "Q: What sits on your shoulder and says 'Pieces of 7! Pieces of 7!'?",
+    "pun": "Q: What sits on your shoulder and says 'Pieces of 9! Pieces of 9!'?",
     "punchline": "A: A Parroty Error!"
   },
   {


### PR DESCRIPTION
While 7 and 8 differ in parity, they have the same 2's complement parity (odd), while 8 and 9 don't (9 is even). Also 9 is one syllable, like 8.